### PR TITLE
Fix snap install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo lxd init --auto
 ### Packing and Installing the Snap
 ```bash
 snapcraft pack
-sudo snap install ./charmed-postgresql*.charm --devmode
+sudo snap install ./charmed-postgresql*.snap --devmode
 ```
 
 ## License


### PR DESCRIPTION
## Issue
Jira ticket: [DPE-1927](https://warthogs.atlassian.net/browse/DPE-1927)

The README contains an invalid command.

## Solution
Fix the command on README.

Closes https://github.com/canonical/charmed-postgresql-snap/issues/8.

[DPE-1927]: https://warthogs.atlassian.net/browse/DPE-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ