### PR TITLE
Remove explicit snap deb dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -152,31 +152,13 @@ parts:
   postgres-debs:
     plugin: nil
     stage-packages:
-      - perl
-      - perl-base
       - postgresql
       - util-linux
       - pgbouncer
       - pgbackrest
       - prometheus-postgres-exporter
-      - python3-psycopg2
       - python3-pysyncobj
       - python3-boto3
-      - postgresql-common
-      - postgresql-client-14
-      - postgresql-contrib
-      - postgresql-14-debversion
-      - postgresql-plpython3-14
-      - python-apt-dev
-      - python3-yaml
-      - python3-urllib3
-      - python3-six
-      - python3-pkg-resources
-      - python3-prettytable
-      - python3-psutil
-      - python3-click
-      - python3-cdiff
-      - python3-dateutil
       - patroni
   wrapper:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -160,6 +160,11 @@ parts:
       - python3-pysyncobj
       - python3-boto3
       - patroni
+      # Landscape deps
+      - postgresql-contrib
+      - postgresql-14-debversion
+      - postgresql-plpython3-14
+      - python-apt-dev
   wrapper:
     plugin: dump
     source: snap/local


### PR DESCRIPTION
# Issue
Since we are now installing the Patroni deb package properly from the PPA, we can remove some of the dependencies of the Snap

# Solution

# Context
* Unfortunately the space savings are marginal (2MB out of about 90MB)
* Updated with COS changes

# Testing
* Tested patronictl manually
* Draft PR canonical/postgresql-operator#132 to verify that integration tests still work

# Release Notes
Remove explicit deb dependencies