### PR TITLE
Enable exporter for cos support

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+# dummy configure needed for enabling configs
+
+exit 0
+

--- a/snap/local/start-exporter.sh
+++ b/snap/local/start-exporter.sh
@@ -6,32 +6,32 @@ EXPORTER_OPTS=""
 EXPORTER_PATH="/usr/bin/prometheus-postgres-exporter"
 SOCKET_PATH="/tmp"
 
-if [ -z "$SNAP" ]; then
+if [ -z "${SNAP}" ]; then
     # When not running as a snap, expect `DATA_SOURCE_NAME` to be set.
-    if [ -z "$DATA_SOURCE_NAME" ]; then
-        echo "DATA_SOURCE_NAME must be set"
+    if [ -z "${DATA_SOURCE_NAME}" ]; then
+        echo "Error: DATA_SOURCE_NAME must be set" 2>&1
         exit 1
     fi
-    exec "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+    exec "${EXPORTER_PATH}" $(echo "${EXPORTER_OPTS}")
 else
     # When running as a snap, expect `exporter.user` and `exporter.password`
     EXPORTER_USER="$(snapctl get exporter.user)"
     EXPORTER_PASS="$(snapctl get exporter.password)"
     EXPORTER_PATH="${SNAP}${EXPORTER_PATH}"
 
-    if [[ -z "$EXPORTER_USER" || -z "$EXPORTER_PASS" ]]; then
-        echo "exporter.user and exporter.password must be set"
+    if [[ -z "${EXPORTER_USER}" || -z "${EXPORTER_PASS}" ]]; then
+        echo "Error: exporter.user and exporter.password must be set" 2>&1
         exit 1
     fi
 
     DATA_SOURCE_NAME="user=${EXPORTER_USER} password=${EXPORTER_PASS} host=${SOCKET_PATH}"
-    DATA_SOURCE_NAME="${DATA_SOURCE_NAME} port=5432 database=postgres"
+    DATA_SOURCE_NAME+=" port=5432 database=postgres"
     # For security measures, daemons should not be run as sudo.
     # Execute as the non-sudo user: snap_daemon.
-    exec "$SNAP"/usr/bin/setpriv \
+    exec "${SNAP}"/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
         --regid snap_daemon -- \
         env DATA_SOURCE_NAME="${DATA_SOURCE_NAME}" \
-        "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+        "${EXPORTER_PATH}" $(echo "${EXPORTER_OPTS}")
 fi

--- a/snap/local/start-exporter.sh
+++ b/snap/local/start-exporter.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eo pipefail # Exit on error
+
+EXPORTER_OPTS=""
+EXPORTER_PATH="/usr/bin/prometheus-postgres-exporter"
+SOCKET_PATH="/tmp"
+
+if [ -z "$SNAP" ]; then
+    # When not running as a snap, expect `DATA_SOURCE_NAME` to be set.
+    if [ -z "$DATA_SOURCE_NAME" ]; then
+        echo "DATA_SOURCE_NAME must be set"
+        exit 1
+    fi
+    exec "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+else
+    # When running as a snap, expect `exporter.user` and `exporter.password`
+    EXPORTER_USER="$(snapctl get exporter.user)"
+    EXPORTER_PASS="$(snapctl get exporter.password)"
+    EXPORTER_PATH="${SNAP}${EXPORTER_PATH}"
+
+    if [[ -z "$EXPORTER_USER" || -z "$EXPORTER_PASS" ]]; then
+        echo "exporter.user and exporter.password must be set"
+        exit 1
+    fi
+
+    DATA_SOURCE_NAME="user=${EXPORTER_USER} password=${EXPORTER_PASS} host=${SOCKET_PATH}"
+    DATA_SOURCE_NAME="${DATA_SOURCE_NAME} port=5432 database=postgres"
+    # For security measures, daemons should not be run as sudo.
+    # Execute as the non-sudo user: snap_daemon.
+    exec "$SNAP"/usr/bin/setpriv \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid snap_daemon -- \
+        env DATA_SOURCE_NAME="${DATA_SOURCE_NAME}" \
+        "$EXPORTER_PATH" $(echo "$EXPORTER_OPTS")
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,7 +142,7 @@ apps:
   pgbouncer:
     command: usr/sbin/pgbouncer
   prometheus-postgres-exporter:
-    command: usr/bin/prometheus-postgres-exporter
+    command: start-exporter.sh
     daemon: simple
     install-mode: disable
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,13 @@ layout:
   /var/cache/postgresql:
     bind: $SNAP_COMMON/var/cache/postgresql
 
+slots:
+  logs:
+    interface: content
+    source:
+      read:
+        - $SNAP_COMMON/var/log/patroni
+
 apps:
   createdb:
     command: usr/bin/createdb

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,12 +51,14 @@ layout:
   /var/cache/postgresql:
     bind: $SNAP_COMMON/var/cache/postgresql
 
+# TODO: Add postgresql log path once configured
 slots:
   logs:
     interface: content
     source:
       read:
         - $SNAP_COMMON/var/log/patroni
+        - $SNAP_COMMON/var/log/pgbackrest
 
 apps:
   createdb:


### PR DESCRIPTION
## Issue

Current snap does not start/configure prometheus exporter nor set a log files path.
[DPE-1776](https://warthogs.atlassian.net/browse/DPE-1776)


## Solution

Add configuration, a startup wrapper and patroni log files access.

## Testing

Snap published as revision 39 under `14/edge/cos` branch

[DPE-1776]: https://warthogs.atlassian.net/browse/DPE-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ