### PR TITLE
Remove additional dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,10 +170,8 @@ parts:
       - python3-boto3
       - patroni
       # Landscape deps
-      - postgresql-contrib
       - postgresql-14-debversion
       - postgresql-plpython3-14
-      - python-apt-dev
   wrapper:
     plugin: dump
     source: snap/local


### PR DESCRIPTION
# Issue
Removing superfluous dependencies, no longer needed by Landscape

# Solution

# Context

# Testing
* Draft PR canonical/postgresql-operator#132 to verify that integration tests still work

# Release Notes
Remove more deb dependencies