### PR TITLE
Use ppa postgres-exporter

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,8 @@ package-repositories:
     ppa: data-platform/pgbackrest
   - type: apt
     ppa: data-platform/pgbouncer
+  - type: apt
+    ppa: data-platform/postgres-exporter
 
 layout:
   /usr/lib/python3/dist-packages:


### PR DESCRIPTION
Switching to PPA provided postgresql prometheus exporter.

Tested on https://github.com/canonical/postgresql-operator/pull/188