### PR TITLE
[DPE-1935] Add postgresql logs to logs plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ slots:
     source:
       read:
         - $SNAP_COMMON/var/log/patroni
+        - $SNAP_COMMON/var/log/postgresql
         - $SNAP_COMMON/var/log/pgbackrest
         - $SNAP_COMMON/var/log/pgbouncer
 


### PR DESCRIPTION
Adding the postgresql logs dir to the logs plugs. This is necessary for COS integration.