### PR TITLE
[DPE-2721] Allow network access for pg_dump, pg_dumpall and pg_restore

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,6 +103,8 @@ apps:
   #   command: usr/bin/pg_receivexlog
   pg-restore:
     command: usr/bin/pg_restore
+    plugs:
+      - network
   pg-upgradecluster:
     command: usr/bin/pg_upgradecluster
   pg-backupcluster:
@@ -111,6 +113,8 @@ apps:
     command: usr/bin/pg_config
   pg-dump:
     command: usr/bin/pg_dump
+    plugs:
+      - network
   pg-lsclusters:
     command: usr/bin/pg_lsclusters
   pg-recvlogical:
@@ -129,6 +133,8 @@ apps:
     command: usr/bin/pg_ctlcluster
   pg-dumpall:
     command: usr/bin/pg_dumpall
+    plugs:
+      - network
   pg-receivewal:
     command: usr/bin/pg_receivewal
   pg-renamecluster:


### PR DESCRIPTION
Add network plug to dump/restore utilities, so that users can connect using host or IP. Tested manually in a local env.