### PR TITLE
[DPE-2726] Add locales

### DIFF
--- a/snap/local/start-patroni.sh
+++ b/snap/local/start-patroni.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # For security measures, daemons should not be run as sudo. Execute patroni as the non-sudo user: snap_daemon.
+export LOCPATH="${SNAP}"/usr/lib/locale
 $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
   --regid snap_daemon -- $SNAP/usr/bin/patroni $SNAP_DATA/etc/patroni/patroni.yaml "$@"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,6 +188,7 @@ parts:
       - python3-pysyncobj
       - python3-boto3
       - patroni
+      - locales-all
       # Landscape deps
       - postgresql-14-debversion
       - postgresql-plpython3-14


### PR DESCRIPTION
## Issue
The `en_US.UTF8` locale is needed for the PostgreSQL charms in order to correctly meet the acceptance criteria from [DPE-1782](https://warthogs.atlassian.net/browse/DPE-1782).

## Solution
Add the `locales-all` package and use it when starting Patroni.

Fixes https://github.com/canonical/charmed-postgresql-snap/issues/24.

[DPE-1782]: https://warthogs.atlassian.net/browse/DPE-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ