### PR TITLE
[DPE-3217] Bump version to 14.10

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 # yamllint disable rule:line-length
 name: charmed-postgresql # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
-version: '14.9' # just for humans, typically '1.2+git' or '1.3.2'
+version: '14.10' # just for humans, typically '1.2+git' or '1.3.2'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management


### PR DESCRIPTION
Latest revision (92) already has 14.10, so increasing the manifest version.