### PR TITLE
[DPE-3159] Add pgvector package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,8 @@ package-repositories:
     ppa: data-platform/postgres-exporter
   - type: apt
     ppa: data-platform/pgbouncer-exporter
+  - type: apt
+    ppa: data-platform/pgvector
 
 layout:
   /usr/lib/python3/dist-packages:
@@ -232,6 +234,7 @@ parts:
       - postgresql-14-icu-ext
       - postgresql-14-postgis-3
       - postgresql-14-postgis-3-scripts
+      - postgresql-14-pgvector
     organize:
       usr/share/doc/postgresql/copyright: licenses/COPYRIGHT-postgresql
       usr/share/doc/util-linux/copyright: licenses/COPYRIGHT-util-linux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -261,6 +261,7 @@ parts:
       usr/share/doc/postgresql-14-tds-fdw/copyright: licenses/COPYRIGHT-tds-fdw
       usr/share/doc/postgresql-14-icu-ext/copyright: licenses/COPYRIGHT-icu-ext
       usr/share/doc/postgresql-14-postgis-3/copyright: licenses/COPYRIGHT-postgis
+      usr/share/doc/postgresql-14-pgvector/copyright: licenses/COPYRIGHT-pgvector
   snap-license:
     plugin: dump
     source: .


### PR DESCRIPTION
Adding a new pgvector package to Charmed PostgreSQL snap.
Debian package is installed from DPE PPA as missing in Jammy
(it is available in Nobel for PostgreSQL 16, therefor
no PPA will be necessary after migration to Nobel/PostgreSQL 16).

The new packages is necessary to provide the vector similarity search for
Postgres 14 and will be available as Charmed PostgreSQL operator extension. 

The new SNAP size will be: +100500GB