### PR TITLE
Add status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-PostgreSQL Snap
+# Charmed PostgreSQL Snap
+[![.github/workflows/publish.yaml](https://github.com/canonical/charmed-postgresql-snap/actions/workflows/publish.yaml/badge.svg)](https://github.com/canonical/charmed-postgresql-snap/actions/workflows/publish.yaml)
+
 This repository contains the packaging metadata for creating a snap of PostgreSQL built from the official Ubuntu repositories.  For more information on snaps, visit [snapcraft.io](https://snapcraft.io/). 
 
 ## Installing the Snap


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added a badge for the "publish" workflow. 