### PR TITLE
[DPE-4345] Disable pgBackRest service initialisation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -240,7 +240,7 @@ parts:
       - locales-all
       # Landscape deps
       - postgresql-14-debversion=1.1.1-5
-      - postgresql-plpython3-14
+      - postgresql-plpython3-14=14.12-0ubuntu0.22.04.1
       - postgresql-contrib=14+238
       - postgresql-plperl-14
       - postgresql-14-similarity

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -240,7 +240,7 @@ parts:
       - locales-all
       # Landscape deps
       - postgresql-14-debversion=1.1.1-5
-      - postgresql-plpython3-14=14.12-0ubuntu0.22.04.1
+      - postgresql-plpython3-14
       - postgresql-contrib=14+238
       - postgresql-plperl-14
       - postgresql-14-similarity

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -182,6 +182,7 @@ apps:
   pgbackrest-service:
     command: start-pgbackrest.sh
     daemon: simple
+    install-mode: disable
     plugs:
       - network
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 # yamllint disable rule:line-length
 name: charmed-postgresql # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
-version: '14.11' # just for humans, typically '1.2+git' or '1.3.2'
+version: '14.12' # just for humans, typically '1.2+git' or '1.3.2'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management
@@ -240,7 +240,7 @@ parts:
       - locales-all
       # Landscape deps
       - postgresql-14-debversion=1.1.1-5
-      - postgresql-plpython3-14=14.11-0ubuntu0.22.04.1
+      - postgresql-plpython3-14=14.12-0ubuntu0.22.04.1
       - postgresql-contrib=14+238
       - postgresql-plperl-14
       - postgresql-14-similarity


### PR DESCRIPTION
## Issue
The pgBackRest TLS service is enabled in the Snap, which makes it start automatically on boot in the charm, creating some noise in the system logs, like the following (from https://github.com/canonical/postgresql-operator/issues/468):
```sh
charmed-postgresql.pgbackrest-service[7546]: ERROR: [037]: server command requires option: tls-server-auth
```

## Solution
Disable the service initialisation in the snap.

Also, update the snap version to 14.12 (because that's the PostgreSQL version we have in the repositories now) and fix the name of the `plpython3` package to match the new PostgreSQL version.

Services in the charm after this fix (`charmed-postgresql.prometheus-postgres-exporter` needs to be disabled in the charm code, but this will probably be done after we add some logic to handle its start after COS is related to the PG charm):
```sh
ubuntu@juju-337094-0:~$ sudo snap services charmed-postgresql
Service                                          Startup   Current   Notes
charmed-postgresql.patroni                       disabled  active    -
charmed-postgresql.pgbackrest-exporter           disabled  inactive  -
charmed-postgresql.pgbackrest-service            disabled  inactive  -
charmed-postgresql.prometheus-postgres-exporter  enabled  inactive  -
```