### PR TITLE
[DPE-5263] Fix `.psql_history` write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.snap
 exported.txt
 *__pycache__*
+.idea

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -24,6 +24,7 @@ sed -i "s:/var/lib/pgbackrest:$VAR_LIB_PGBACKREST:g" $SNAP_DATA/etc/pgbackrest/p
 echo "pg1-path=$SNAP_COMMON/var/lib/postgresql" >> $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
 echo "pg1-user=snap_daemon" >> $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
 touch $SNAP_COMMON/.psql_history
+chown 584788:root $SNAP_COMMON/.psql_history
 
 chown -R 584788:root $SNAP_COMMON/*
 chown -R 584788:root $SNAP_DATA/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -23,6 +23,7 @@ cp $SNAP/etc/pgbackrest.conf $SNAP_DATA/etc/pgbackrest
 sed -i "s:/var/lib/pgbackrest:$VAR_LIB_PGBACKREST:g" $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
 echo "pg1-path=$SNAP_COMMON/var/lib/postgresql" >> $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
 echo "pg1-user=snap_daemon" >> $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
+touch $SNAP_COMMON/.psql_history
 
 chown -R 584788:root $SNAP_COMMON/*
 chown -R 584788:root $SNAP_DATA/*

--- a/snap/local/etc/postgresql-common/.psqlrc
+++ b/snap/local/etc/postgresql-common/.psqlrc
@@ -1,0 +1,1 @@
+\set HISTFILE /var/snap/charmed-postgresql/common/.psql_history

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -216,6 +216,8 @@ apps:
       - network-bind
   psql:
     command: usr/bin/psql
+    environment:
+      PSQLRC: /snap/charmed-postgresql/current/etc/postgresql-common/.psqlrc
     plugs:
       - network
   syncobj-admin:


### PR DESCRIPTION
## Issue
After running some commands through `psql` (the binary available in the snap) and exiting from it, it cannot save those commands to the history file (`~/.psql_history` by default), which allows them to be used again in a later session.
https://github.com/canonical/postgresql-operator/issues/595

## Solution
