### PR TITLE
[DPE-6344] Add pebble service dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -290,6 +290,15 @@ parts:
       usr/share/doc/postgresql-14-pgaudit/copyright: licenses/COPYRIGHT-pgaudit
       usr/share/doc/timescaledb-postgresql-14/copyright: licenses/COPYRIGHT-timescaledb
       usr/share/doc/golang-github-woblerr-pgbackrest-exporter/copyright: licenses/COPYRIGHT-pgbackrest-exporter
+  services-deps:
+    plugin: python
+    source: .
+    build-packages:
+      - libpq-dev
+      - libldap2-dev
+      - libsasl2-dev
+    python-packages:
+      - postgresql-ldap-sync==0.2.1
   snap-license:
     plugin: dump
     source: .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -238,6 +238,7 @@ parts:
       - patroni=3.1.2-0ubuntu0.22.04.1~ppa2
       - golang-github-woblerr-pgbackrest-exporter=0.16.2+ds1-0ubuntu0.22.04.1~ppa1
       - locales-all
+      - libldap-common
       # Landscape deps
       - postgresql-14-debversion=1.1.1-5
       - postgresql-plpython3-14=14.15-0ubuntu0.22.04.1
@@ -269,6 +270,7 @@ parts:
       usr/share/doc/python3-boto3/copyright: licenses/COPYRIGHT-python3-boto3
       usr/share/doc/patroni/copyright: licenses/COPYRIGHT-patroni
       usr/share/doc/locales-all/copyright: licenses/COPYRIGHT-locales-all
+      usr/share/doc/libldap-common/copyright: licenses/COPYRIGHT-libldap-common
       usr/share/doc/postgresql-14-debversion/copyright: licenses/COPYRIGHT-postgresql-14-debversion
       usr/share/doc/postgresql-plpython3-14/copyright: licenses/COPYRIGHT-postgresql-plpython3-14
       usr/share/doc/postgresql-contrib/copyright: licenses/COPYRIGHT-postgresql-contrib


### PR DESCRIPTION
This PR brings dependencies introduced in PR https://github.com/canonical/charmed-postgresql-rock/pull/78 **one abstraction level lower**, so that the required config / python packages needed for the PostgreSQL - LDAP integration could be used both in the VM and K8s charms.

### Clarifications:
- We can leverage the [Python plugin](https://canonical-snapcraft.readthedocs-hosted.com/en/8.4.0/reference/plugins/python_plugin/) to simplify the Python packages installation setup.
- PostgreSQL LDAP TLS depends on both `libldap-2.5-0` and `libldap-common` packages, but the former is already installed, given that is listed as a direct dependency for the `postgresql-14` binary (even if it does not appear listed on the rock, as it gets installed via _snap unpacking_, instead of standard _apt install_).
