### PR TITLE
[DPE-6344] Add ldap-sync service 

### DIFF
--- a/snap/local/scripts/ldap-synchronizer.py
+++ b/snap/local/scripts/ldap-synchronizer.py
@@ -1,0 +1,129 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Service for synchronizing users from LDAP."""
+
+import atexit
+import json
+import logging
+import os
+import time
+
+from postgresql_ldap_sync.clients import (
+    BaseLDAPClient,
+    BasePostgreClient,
+    DefaultPostgresClient,
+    GLAuthClient,
+)
+from postgresql_ldap_sync.matcher import DefaultMatcher
+
+logger = logging.getLogger(__name__)
+
+
+def _create_ldap_client() -> GLAuthClient:
+    return GLAuthClient(
+        host=os.environ["LDAP_HOST"],
+        port=os.environ["LDAP_PORT"],
+        base_dn=os.environ["LDAP_BASE_DN"],
+        bind_username=os.environ["LDAP_BIND_USERNAME"],
+        bind_password=os.environ["LDAP_BIND_PASSWORD"],
+    )
+
+
+def _create_psql_client() -> DefaultPostgresClient:
+    return DefaultPostgresClient(
+        host=os.environ["POSTGRES_HOST"],
+        port=os.environ["POSTGRES_PORT"],
+        database=os.environ["POSTGRES_DATABASE"],
+        username=os.environ["POSTGRES_USERNAME"],
+        password=os.environ["POSTGRES_PASSWORD"],
+    )
+
+
+def _deserialize_group_mappings() -> list[tuple[str]]:
+    return json.loads(os.environ["LDAP_GROUP_MAPPINGS"])
+
+
+def _deserialize_group_identity() -> str:
+    return json.loads(os.environ["LDAP_GROUP_IDENTITY"])
+
+
+def _sync_users(
+    ldap_client: BaseLDAPClient,
+    psql_client: BasePostgreClient,
+    group_mappings: list[tuple],
+    group_identity: str,
+) -> None:
+    """Synchronize LDAP users to PostgreSQL."""
+    ldap_users_groups = [ldap_group for ldap_group, _ in group_mappings]
+    ldap_users = ldap_client.search_users(from_groups=ldap_users_groups)
+    psql_users = psql_client.search_users(from_group=group_identity)
+
+    roles_matcher = DefaultMatcher()
+    users_created = 0
+    users_deleted = 0
+
+    for match in roles_matcher.match_users(ldap_users, psql_users):
+        if match.should_keep:
+            logger.debug(f"Ignoring LDAP user '{match.name}'")
+        if match.should_create:
+            logger.debug(f"Creating LDAP user '{match.name}' into PostgreSQL")
+            psql_client.create_user(match.name)
+            psql_client.grant_group_memberships([group_identity], [match.name])
+            users_created += 1
+        if match.should_delete:
+            logger.debug(f"Deleting LDAP user '{match.name}' from PostgreSQL")
+            psql_client.revoke_group_memberships([group_identity], [match.name])
+            psql_client.delete_user(match.name)
+            users_deleted += 1
+
+    logger.info(f"Created {users_created} users")
+    logger.info(f"Deleted {users_deleted} users")
+
+
+def _sync_members(
+    ldap_client: BaseLDAPClient,
+    psql_client: BasePostgreClient,
+    group_mappings: list[tuple],
+    group_identity: str,
+) -> None:
+    """Synchronize LDAP memberships to PostgreSQL."""
+    psql_groups = psql_client.search_groups()
+    psql_groups = list(psql_groups)
+    psql_groups.remove(group_identity)
+
+    memberships_updated = 0
+
+    for ldap_group, psql_group in group_mappings:
+        ldap_users = ldap_client.search_users(from_groups=[ldap_group])
+        ldap_users = list(ldap_users)
+
+        logger.debug(f"Mapping LDAP group '{ldap_group}' within PostgreSQL")
+        psql_client.revoke_group_memberships(psql_groups, ldap_users)
+        psql_client.grant_group_memberships([psql_group], ldap_users)
+        memberships_updated += len(ldap_users)
+
+    logger.info(f"Updated {memberships_updated} group memberships")
+
+
+def main():
+    """Main loop to periodically synchronize LDAP users."""
+    ldap_client = _create_ldap_client()
+    psql_client = _create_psql_client()
+
+    atexit.register(psql_client.close)
+
+    group_mappings = _deserialize_group_mappings()
+    group_identity = _deserialize_group_identity()
+
+    while True:
+        logger.info("Synchronizing LDAP users to PostgreSQL")
+        _sync_users(ldap_client, psql_client, group_mappings, group_identity)
+        _sync_members(ldap_client, psql_client, group_mappings, group_identity)
+
+        # Wait 30 seconds before executing the synchronizer again
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    main()

--- a/snap/local/start-ldap-synchronizer.sh
+++ b/snap/local/start-ldap-synchronizer.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Exit on error
+set -eo pipefail
+
+SHELL_SCRIPTS_PATH="$(realpath $(dirname $0))"
+PYTHON_SCRIPT_PATH="${SHELL_SCRIPTS_PATH}/scripts/ldap-synchronizer.py"
+
+if [ -z "${SNAP}" ]; then
+  exec /usr/bin/python3 ${PYTHON_SCRIPT_PATH}
+  exit 0
+fi
+
+# For security measures, daemons should not be run as sudo.
+# Execute as the non-sudo user: snap_daemon.
+exec "${SNAP}"/usr/bin/setpriv \
+  --clear-groups \
+  --reuid snap_daemon \
+  --regid snap_daemon -- \
+  env LDAP_HOST="$(snapctl get ldap-sync.ldap_host)" \
+  env LDAP_PORT="$(snapctl get ldap-sync.ldap_port)" \
+  env LDAP_BASE_DN="$(snapctl get ldap-sync.ldap_base_dn)" \
+  env LDAP_BIND_USERNAME="$(snapctl get ldap-sync.ldap_bind_username)" \
+  env LDAP_BIND_PASSWORD="$(snapctl get ldap-sync.ldap_bind_password)" \
+  env LDAP_GROUP_IDENTITY="$(snapctl get ldap-sync.ldap_group_identity)" \
+  env LDAP_GROUP_MAPPINGS="$(snapctl get ldap-sync.ldap_group_mappings)" \
+  env POSTGRES_HOST="$(snapctl get ldap-sync.postgres_host)" \
+  env POSTGRES_PORT="$(snapctl get ldap-sync.postgres_port)" \
+  env POSTGRES_DATABASE="$(snapctl get ldap-sync.postgres_database)" \
+  env POSTGRES_USERNAME="$(snapctl get ldap-sync.postgres_username)" \
+  env POSTGRES_PASSWORD="$(snapctl get ldap-sync.postgres_password)" \
+  $SNAP/bin/python3 ${PYTHON_SCRIPT_PATH}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,6 +101,13 @@ apps:
     command: usr/bin/createdb
   createuser:
     command: usr/bin/createuser
+  ldap-sync:
+    command: start-ldap-synchronizer.sh
+    daemon: simple
+    install-mode: disable
+    plugs:
+      - network
+      - network-bind
   patroni:
     command: start-patroni.sh
     daemon: simple
@@ -236,7 +243,7 @@ parts:
       - python3-boto3
       - patroni=3.1.2-0ubuntu0.22.04.1~ppa2
       - golang-github-woblerr-pgbackrest-exporter=0.16.2+ds1-0ubuntu0.22.04.1~ppa1
-      - python3-postgresql-ldap-sync=0.2.1-0ubuntu0.25.04.1~ppa3
+      - python3-postgresql-ldap-sync=0.3.1-0ubuntu1
       - locales-all
       - libldap-common
       # Landscape deps
@@ -266,6 +273,7 @@ parts:
       usr/share/doc/pgbackrest/copyright: licenses/COPYRIGHT-pgbackrest
       usr/share/doc/prometheus-postgres-exporter/copyright: licenses/COPYRIGHT-prometheus-postgres-exporter
       usr/share/doc/golang-github-prometheus-community-pgbouncer-exporter/copyright: licenses/COPYRIGHT-golang-github-prometheus-community-pgbouncer-exporter
+      usr/share/doc/python3-postgresql-ldap-sync/copyright: licenses/COPYRIGHT-python3-postgresql-ldap-sync
       usr/share/doc/python3-pysyncobj/copyright: licenses/COPYRIGHT-python3-pysyncobj
       usr/share/doc/python3-boto3/copyright: licenses/COPYRIGHT-python3-boto3
       usr/share/doc/patroni/copyright: licenses/COPYRIGHT-patroni
@@ -290,7 +298,6 @@ parts:
       usr/share/doc/postgresql-14-pgaudit/copyright: licenses/COPYRIGHT-pgaudit
       usr/share/doc/timescaledb-postgresql-14/copyright: licenses/COPYRIGHT-timescaledb
       usr/share/doc/golang-github-woblerr-pgbackrest-exporter/copyright: licenses/COPYRIGHT-pgbackrest-exporter
-      usr/share/doc/python3-postgresql-ldap-syn/copyright: licenses/COPYRIGHT-python3-postgresql-ldap-sync
   snap-license:
     plugin: dump
     source: .


### PR DESCRIPTION
This PR defines the `ldap-sync` service, in order to make it available both for the PostgreSQL K8s and VMs charms.

The [ldap-synchronizer.py](https://github.com/canonical/charmed-postgresql-snap/blob/sinclert/ldap-sync-service/snap/local/scripts/ldap-synchronizer.py) script was originally going to be proposed within the PostgreSQL K8s codebase. However, given that the LDAP support needs to be added to both VM and K8s versions, the snap is the only common place to avoid defining the same script twice.

### Additional changes

- Bumps `postgresql-ldap-sync` Python package to version `0.3.0` (depends on [this PR](https://github.com/canonical/postgresql-ldap-sync/pull/12)).