### PR TITLE
Create SECURITY.md

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,6 @@ concurrency:
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   lint:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security policy
+
+## What qualifies as a security issue
+
+Credentials leakage, outdated dependencies with known vulnerabilities, and
+other issues that could lead to unprivileged or unauthorized access to the
+database or the system.
+
+## Reporting a vulnerability
+
+The easiest way to report a security issue is through
+[GitHub](https://github.com/canonical/charmed-postgresql-snap/security/advisories/new). See
+[Privately reporting a security
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions.
+
+The repository admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then handle figuring out a fix, getting a CVE
+assigned and coordinating the release of the fix.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.


### PR DESCRIPTION
## Issue
Lack of explicit security policy.

## Solution
Add security policy file.

In parallel, waiting for [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) to be enabled.