### PR TITLE
[DPE-6345] Copy LDAP config to data folder

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,6 +2,7 @@
 
 VAR_LIB_PGBACKREST=$SNAP_COMMON/var/lib/pgbackrest
 
+mkdir -p $SNAP_DATA/etc/ldap
 mkdir -p $SNAP_DATA/etc/patroni
 mkdir -p $SNAP_DATA/etc/postgresql
 mkdir -p $SNAP_DATA/etc/pgbackrest
@@ -19,6 +20,7 @@ mkdir -p $SNAP_COMMON/var/log/postgresql
 
 cp $SNAP/config/patroni.yaml $SNAP_DATA/etc/patroni
 cp $SNAP/etc/pgbackrest.conf $SNAP_DATA/etc/pgbackrest
+cp $SNAP/etc/ldap/ldap.conf $SNAP_DATA/etc/ldap
 
 sed -i "s:/var/lib/pgbackrest:$VAR_LIB_PGBACKREST:g" $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
 echo "pg1-path=$SNAP_COMMON/var/lib/postgresql" >> $SNAP_DATA/etc/pgbackrest/pgbackrest.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,12 @@ slots:
         - $SNAP_COMMON/var/log/pgbackrest
         - $SNAP_COMMON/var/log/pgbouncer
 
+environment:
+  # This variable will tell the LDAP binary where to get its configuration.
+  # The default /etc/ldap/ldap.conf file is not readable for the snap user.
+  # (https://manpages.debian.org/jessie/libldap-2.4-2/ldap.conf.5.en.html)
+  LDAPCONF: $SNAP_DATA/etc/ldap/ldap.conf
+
 apps:
   createdb:
     command: usr/bin/createdb


### PR DESCRIPTION
This PR copies the `ldap.conf` file created by the installation of the [libldap-common](https://packages.debian.org/sid/libldap-common) package, to the location where PostgreSQL snap required configurations must be placed. In addition, it exports the `LDAPCONF` env. variable to point to such file, given that the default LDAP config location (`/etc/ldap/ldap.conf`) is not readable.

This approach is also the one followed by @Gu1nness in this MongoDB snap [PR](https://github.com/canonical/charmed-mongodb-snap/pull/57).

