### PR TITLE
 [DPE-6965] Stop creating $SNAP_COMMON/data/db (unnecessary) + polishing

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,33 +1,33 @@
 #!/bin/bash
 
-ETC_PGBACKREST_CONF=$SNAP_DATA/etc/pgbackrest/pgbackrest.conf
-VAR_LIB_PGBACKREST=$SNAP_COMMON/var/lib/pgbackrest
-VAR_LIB_POSTGRESQL=$SNAP_COMMON/var/lib/postgresql
+ETC_PGBACKREST_CONF=${SNAP_DATA}/etc/pgbackrest/pgbackrest.conf
+VAR_LIB_PGBACKREST=${SNAP_COMMON}/var/lib/pgbackrest
+VAR_LIB_POSTGRESQL=${SNAP_COMMON}/var/lib/postgresql
 
 # /etc
-mkdir -p $SNAP_DATA/etc/ldap
-mkdir -p $SNAP_DATA/etc/patroni
-mkdir -p $SNAP_DATA/etc/postgresql
-mkdir -p $SNAP_DATA/etc/pgbackrest
-mkdir -p $SNAP_DATA/etc/pgbouncer
+mkdir -p ${SNAP_DATA}/etc/ldap
+mkdir -p ${SNAP_DATA}/etc/patroni
+mkdir -p ${SNAP_DATA}/etc/postgresql
+mkdir -p ${SNAP_DATA}/etc/pgbackrest
+mkdir -p ${SNAP_DATA}/etc/pgbouncer
 
 # /var/lib
-mkdir -p $VAR_LIB_PGBACKREST
-mkdir -p $VAR_LIB_POSTGRESQL
+mkdir -p ${VAR_LIB_PGBACKREST}
+mkdir -p ${VAR_LIB_POSTGRESQL}
 
 # /var/log
-mkdir -p $SNAP_COMMON/var/log/patroni
-mkdir -p $SNAP_COMMON/var/log/pgbackrest
-mkdir -p $SNAP_COMMON/var/log/pgbouncer
-mkdir -p $SNAP_COMMON/var/log/postgresql
+mkdir -p ${SNAP_COMMON}/var/log/patroni
+mkdir -p ${SNAP_COMMON}/var/log/pgbackrest
+mkdir -p ${SNAP_COMMON}/var/log/pgbouncer
+mkdir -p ${SNAP_COMMON}/var/log/postgresql
 
-cp $SNAP/config/patroni.yaml $SNAP_DATA/etc/patroni
-cp $SNAP/etc/pgbackrest.conf $SNAP_DATA/etc/pgbackrest
-cp $SNAP/etc/ldap/ldap.conf $SNAP_DATA/etc/ldap
+cp ${SNAP}/config/patroni.yaml ${SNAP_DATA}/etc/patroni
+cp ${SNAP}/etc/pgbackrest.conf ${SNAP_DATA}/etc/pgbackrest
+cp ${SNAP}/etc/ldap/ldap.conf ${SNAP_DATA}/etc/ldap
 
-sed -i "s:/var/lib/pgbackrest:$VAR_LIB_PGBACKREST:g" $ETC_PGBACKREST_CONF
-echo "pg1-path=$VAR_LIB_POSTGRESQL" >> $ETC_PGBACKREST_CONF
-echo "pg1-user=snap_daemon" >> $ETC_PGBACKREST_CONF
+sed -i "s:/var/lib/pgbackrest:${VAR_LIB_PGBACKREST}:g" ${ETC_PGBACKREST_CONF}
+echo "pg1-path=${VAR_LIB_POSTGRESQL}" >> ${ETC_PGBACKREST_CONF}
+echo "pg1-user=snap_daemon" >> ${ETC_PGBACKREST_CONF}
 
-chown -R 584788:root $SNAP_COMMON/*
-chown -R 584788:root $SNAP_DATA/*
+chown -R 584788:root ${SNAP_COMMON}/*
+chown -R 584788:root ${SNAP_DATA}/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,7 +10,6 @@ mkdir -p $SNAP_DATA/etc/pgbouncer
 
 mkdir -p $VAR_LIB_PGBACKREST
 mkdir -p $SNAP_COMMON/postgresql.failed
-mkdir -p $SNAP_COMMON/data/db
 
 mkdir -p $SNAP_COMMON/var/lib/postgresql
 mkdir -p $SNAP_COMMON/var/log/patroni

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -9,7 +9,6 @@ mkdir -p $SNAP_DATA/etc/pgbackrest
 mkdir -p $SNAP_DATA/etc/pgbouncer
 
 mkdir -p $VAR_LIB_PGBACKREST
-mkdir -p $SNAP_COMMON/postgresql.failed
 
 mkdir -p $SNAP_COMMON/var/lib/postgresql
 mkdir -p $SNAP_COMMON/var/log/patroni

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,33 +1,33 @@
 #!/bin/bash
 
-ETC_PGBACKREST_CONF=${SNAP_DATA}/etc/pgbackrest/pgbackrest.conf
-VAR_LIB_PGBACKREST=${SNAP_COMMON}/var/lib/pgbackrest
-VAR_LIB_POSTGRESQL=${SNAP_COMMON}/var/lib/postgresql
+ETC_PGBACKREST_CONF="${SNAP_DATA}/etc/pgbackrest/pgbackrest.conf"
+VAR_LIB_PGBACKREST="${SNAP_COMMON}/var/lib/pgbackrest"
+VAR_LIB_POSTGRESQL="${SNAP_COMMON}/var/lib/postgresql"
 
 # /etc
-mkdir -p ${SNAP_DATA}/etc/ldap
-mkdir -p ${SNAP_DATA}/etc/patroni
-mkdir -p ${SNAP_DATA}/etc/postgresql
-mkdir -p ${SNAP_DATA}/etc/pgbackrest
-mkdir -p ${SNAP_DATA}/etc/pgbouncer
+mkdir -p "${SNAP_DATA}/etc/ldap"
+mkdir -p "${SNAP_DATA}/etc/patroni"
+mkdir -p "${SNAP_DATA}/etc/postgresql"
+mkdir -p "${SNAP_DATA}/etc/pgbackrest"
+mkdir -p "${SNAP_DATA}/etc/pgbouncer"
 
 # /var/lib
-mkdir -p ${VAR_LIB_PGBACKREST}
-mkdir -p ${VAR_LIB_POSTGRESQL}
+mkdir -p "${VAR_LIB_PGBACKREST}"
+mkdir -p "${VAR_LIB_POSTGRESQL}"
 
 # /var/log
-mkdir -p ${SNAP_COMMON}/var/log/patroni
-mkdir -p ${SNAP_COMMON}/var/log/pgbackrest
-mkdir -p ${SNAP_COMMON}/var/log/pgbouncer
-mkdir -p ${SNAP_COMMON}/var/log/postgresql
+mkdir -p "${SNAP_COMMON}/var/log/patroni"
+mkdir -p "${SNAP_COMMON}/var/log/pgbackrest"
+mkdir -p "${SNAP_COMMON}/var/log/pgbouncer"
+mkdir -p "${SNAP_COMMON}/var/log/postgresql"
 
-cp ${SNAP}/config/patroni.yaml ${SNAP_DATA}/etc/patroni
-cp ${SNAP}/etc/pgbackrest.conf ${SNAP_DATA}/etc/pgbackrest
-cp ${SNAP}/etc/ldap/ldap.conf ${SNAP_DATA}/etc/ldap
+cp "${SNAP}/config/patroni.yaml" "${SNAP_DATA}/etc/patroni"
+cp "${SNAP}/etc/pgbackrest.conf" "${SNAP_DATA}/etc/pgbackrest"
+cp "${SNAP}/etc/ldap/ldap.conf" "${SNAP_DATA}/etc/ldap"
 
-sed -i "s:/var/lib/pgbackrest:${VAR_LIB_PGBACKREST}:g" ${ETC_PGBACKREST_CONF}
-echo "pg1-path=${VAR_LIB_POSTGRESQL}" >> ${ETC_PGBACKREST_CONF}
-echo "pg1-user=snap_daemon" >> ${ETC_PGBACKREST_CONF}
+sed -i "s:/var/lib/pgbackrest:${VAR_LIB_PGBACKREST}:g" "${ETC_PGBACKREST_CONF}"
+echo "pg1-path=${VAR_LIB_POSTGRESQL}" >> "${ETC_PGBACKREST_CONF}"
+echo "pg1-user=snap_daemon" >> "${ETC_PGBACKREST_CONF}"
 
-chown -R 584788:root ${SNAP_COMMON}/*
-chown -R 584788:root ${SNAP_DATA}/*
+chown -R 584788:root "${SNAP_COMMON}"/*
+chown -R 584788:root "${SNAP_DATA}"/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,16 +1,21 @@
 #!/bin/bash
 
+ETC_PGBACKREST_CONF=$SNAP_DATA/etc/pgbackrest/pgbackrest.conf
 VAR_LIB_PGBACKREST=$SNAP_COMMON/var/lib/pgbackrest
+VAR_LIB_POSTGRESQL=$SNAP_COMMON/var/lib/postgresql
 
+# /etc
 mkdir -p $SNAP_DATA/etc/ldap
 mkdir -p $SNAP_DATA/etc/patroni
 mkdir -p $SNAP_DATA/etc/postgresql
 mkdir -p $SNAP_DATA/etc/pgbackrest
 mkdir -p $SNAP_DATA/etc/pgbouncer
 
+# /var/lib
 mkdir -p $VAR_LIB_PGBACKREST
+mkdir -p $VAR_LIB_POSTGRESQL
 
-mkdir -p $SNAP_COMMON/var/lib/postgresql
+# /var/log
 mkdir -p $SNAP_COMMON/var/log/patroni
 mkdir -p $SNAP_COMMON/var/log/pgbackrest
 mkdir -p $SNAP_COMMON/var/log/pgbouncer
@@ -20,9 +25,9 @@ cp $SNAP/config/patroni.yaml $SNAP_DATA/etc/patroni
 cp $SNAP/etc/pgbackrest.conf $SNAP_DATA/etc/pgbackrest
 cp $SNAP/etc/ldap/ldap.conf $SNAP_DATA/etc/ldap
 
-sed -i "s:/var/lib/pgbackrest:$VAR_LIB_PGBACKREST:g" $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
-echo "pg1-path=$SNAP_COMMON/var/lib/postgresql" >> $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
-echo "pg1-user=snap_daemon" >> $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
+sed -i "s:/var/lib/pgbackrest:$VAR_LIB_PGBACKREST:g" $ETC_PGBACKREST_CONF
+echo "pg1-path=$VAR_LIB_POSTGRESQL" >> $ETC_PGBACKREST_CONF
+echo "pg1-user=snap_daemon" >> $ETC_PGBACKREST_CONF
 
 chown -R 584788:root $SNAP_COMMON/*
 chown -R 584788:root $SNAP_DATA/*


### PR DESCRIPTION
# Issue:

The default postgresql charm has confusing folder `db`:
```
ubuntu@juju-f077a9-0:~$ ls -la /var/snap/charmed-postgresql/common/data/
...
drwxr-xr-x 2 snap_daemon root 4096 Jul  3 14:35 archive
drwxr-xr-x 2 snap_daemon root 4096 Jul  3 14:36 db  <<<<<<<<<<<<
drwx------ 3 snap_daemon root 4096 Jul  3 14:37 logs
drwx------ 3 snap_daemon root 4096 Jul  3 14:45 temp
```
While the real DB is in `$SNAP_COMMON/var/lib/postgresql` see commit fb7433b97da28cde5b974671d9077cadc23ff876.

# Solution:

Stop creating unnecessary and confusing folder.
Polish the snap while we are here:
 * stop creating unnecessary $SNAP_COMMON/postgresql.failed (it is Patroni internals)
 * use common logic with code duplicates
 * follow the common Google Shell codestyle
 * fix all shellcheck warnings