### PR TITLE
[DPE-7691] Use _daemon_ (UID:584792) instead of snap_daemon (UID:584788)

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -27,7 +27,7 @@ cp "${SNAP}/etc/ldap/ldap.conf" "${SNAP_DATA}/etc/ldap"
 
 sed -i "s:/var/lib/pgbackrest:${VAR_LIB_PGBACKREST}:g" "${ETC_PGBACKREST_CONF}"
 echo "pg1-path=${VAR_LIB_POSTGRESQL}" >> "${ETC_PGBACKREST_CONF}"
-echo "pg1-user=snap_daemon" >> "${ETC_PGBACKREST_CONF}"
+echo "pg1-user=_daemon_" >> "${ETC_PGBACKREST_CONF}"
 
-chown -R 584788:root "${SNAP_COMMON}"/*
-chown -R 584788:root "${SNAP_DATA}"/*
+chown -R 584792:root "${SNAP_COMMON}"/*
+chown -R 584792:root "${SNAP_DATA}"/*

--- a/snap/local/start-exporter.sh
+++ b/snap/local/start-exporter.sh
@@ -27,11 +27,11 @@ else
     DATA_SOURCE_NAME="user=${EXPORTER_USER} password=${EXPORTER_PASS} host=${SOCKET_PATH}"
     DATA_SOURCE_NAME+=" port=5432 database=postgres"
     # For security measures, daemons should not be run as sudo.
-    # Execute as the non-sudo user: snap_daemon.
+    # Execute as the non-sudo user: _daemon_.
     exec "${SNAP}"/usr/bin/setpriv \
         --clear-groups \
-        --reuid snap_daemon \
-        --regid snap_daemon -- \
+        --reuid _daemon_ \
+        --regid _daemon_ -- \
         env DATA_SOURCE_NAME="${DATA_SOURCE_NAME}" \
         "${EXPORTER_PATH}" $(echo "${EXPORTER_OPTS}")
 fi

--- a/snap/local/start-ldap-synchronizer.sh
+++ b/snap/local/start-ldap-synchronizer.sh
@@ -12,11 +12,11 @@ if [ -z "${SNAP}" ]; then
 fi
 
 # For security measures, daemons should not be run as sudo.
-# Execute as the non-sudo user: snap_daemon.
+# Execute as the non-sudo user: _daemon_.
 exec "${SNAP}"/usr/bin/setpriv \
   --clear-groups \
-  --reuid snap_daemon \
-  --regid snap_daemon -- \
+  --reuid _daemon_ \
+  --regid _daemon_ -- \
   env LDAP_HOST="$(snapctl get ldap-sync.ldap_host)" \
   env LDAP_PORT="$(snapctl get ldap-sync.ldap_port)" \
   env LDAP_BASE_DN="$(snapctl get ldap-sync.ldap_base_dn)" \

--- a/snap/local/start-patroni.sh
+++ b/snap/local/start-patroni.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# For security measures, daemons should not be run as sudo. Execute patroni as the non-sudo user: snap_daemon.
+# For security measures, daemons should not be run as sudo. Execute patroni as the non-sudo user: _daemon_.
 export LOCPATH="${SNAP}"/usr/lib/locale
-$SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/patroni $SNAP_DATA/etc/patroni/patroni.yaml "$@"
+$SNAP/usr/bin/setpriv --clear-groups --reuid _daemon_ \
+  --regid _daemon_ -- $SNAP/usr/bin/patroni $SNAP_DATA/etc/patroni/patroni.yaml "$@"
 

--- a/snap/local/start-pgb-exporter.sh
+++ b/snap/local/start-pgb-exporter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# For security measures, daemons should not be run as sudo. Execute pgbouncer_exporter as the non-sudo user: snap_daemon.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/pgbouncer_exporter "$@"
+# For security measures, daemons should not be run as sudo. Execute pgbouncer_exporter as the non-sudo user: _daemon_.
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid _daemon_ \
+  --regid _daemon_ -- $SNAP/usr/bin/pgbouncer_exporter "$@"

--- a/snap/local/start-pgbackrest-exporter.sh
+++ b/snap/local/start-pgbackrest-exporter.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# For security measures, daemons should not be run as sudo. Execute pgbackrest_exporter as the non-sudo user: snap_daemon.
-$SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/pgbackrest_exporter --backrest.config="/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf" "$@"
+# For security measures, daemons should not be run as sudo. Execute pgbackrest_exporter as the non-sudo user: _daemon_.
+$SNAP/usr/bin/setpriv --clear-groups --reuid _daemon_ \
+  --regid _daemon_ -- $SNAP/usr/bin/pgbackrest_exporter --backrest.config="/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf" "$@"
 

--- a/snap/local/start-pgbackrest.sh
+++ b/snap/local/start-pgbackrest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# For security measures, daemons should not be run as sudo. Execute pgbackrest as the non-sudo user: snap_daemon.
-$SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/pgbackrest server --config=$SNAP_DATA/etc/pgbackrest/pgbackrest.conf "$@"
+# For security measures, daemons should not be run as sudo. Execute pgbackrest as the non-sudo user: _daemon_.
+$SNAP/usr/bin/setpriv --clear-groups --reuid _daemon_ \
+  --regid _daemon_ -- $SNAP/usr/bin/pgbackrest server --config=$SNAP_DATA/etc/pgbackrest/pgbackrest.conf "$@"
 

--- a/snap/local/start-pgbouncer.sh
+++ b/snap/local/start-pgbouncer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# For security measures, daemons should not be run as sudo. Execute pgbouncer as the non-sudo user: snap_daemon.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/sbin/pgbouncer "$@"
+# For security measures, daemons should not be run as sudo. Execute pgbouncer as the non-sudo user: _daemon_.
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid _daemon_ \
+  --regid _daemon_ -- $SNAP/usr/sbin/pgbouncer "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ grade: stable
 confinement: strict
 
 system-usernames:
-  snap_daemon: shared
+  _daemon_: shared
 
 plugs:
   shared-memory:


### PR DESCRIPTION
# Issue:

The snap user `snap_daemon` has been deprecated by SNAP team.
See: https://forum.snapcraft.io/t/system-usernames/13386

# Solution:

Use new user `_daemon_` for PG16+ to avoid unnecessary data ownership changes in the future.