### PR TITLE
DPE-7968: Remove unnecessary python3-boto3 (fixes CVE-2023-37920)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -280,7 +280,6 @@ parts:
       usr/share/doc/golang-github-prometheus-community-pgbouncer-exporter/copyright: licenses/COPYRIGHT-golang-github-prometheus-community-pgbouncer-exporter
       usr/share/doc/python3-postgresql-ldap-sync/copyright: licenses/COPYRIGHT-python3-postgresql-ldap-sync
       usr/share/doc/python3-pysyncobj/copyright: licenses/COPYRIGHT-python3-pysyncobj
-      usr/share/doc/python3-boto3/copyright: licenses/COPYRIGHT-python3-boto3
       usr/share/doc/patroni/copyright: licenses/COPYRIGHT-patroni
       usr/share/doc/locales-all/copyright: licenses/COPYRIGHT-locales-all
       usr/share/doc/libldap-common/copyright: licenses/COPYRIGHT-libldap-common

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -246,7 +246,6 @@ parts:
       - prometheus-postgres-exporter=0.12.1-0ubuntu0.22.04.1~ppa1
       - golang-github-prometheus-community-pgbouncer-exporter=0.7.0-0ubuntu0.22.04.1~ppa1
       - python3-pysyncobj=0.3.12-0ubuntu0.22.04.1~ppa1
-      - python3-boto3
       - patroni=3.1.2-0ubuntu0.22.04.1~ppa2
       - golang-github-woblerr-pgbackrest-exporter=0.16.2+ds1-0ubuntu0.22.04.1~ppa1
       - python3-postgresql-ldap-sync=0.3.2-0ubuntu1


### PR DESCRIPTION
The `python3-boto3` installs `python3-requests`, which install `python3-certifi`
which has open CVEs (e.g. CVE-2023-37920) in Jammy.

Removing it as not-necessary (added in the initial commit bee734a).