### PR TITLE
DPE-8296 Bump PostgreSQL to 14.19

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 # yamllint disable rule:line-length
 name: charmed-postgresql
 base: core22
-version: '14.18'
+version: '14.19'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management
@@ -253,7 +253,7 @@ parts:
       - libldap-common
       # Landscape deps
       - postgresql-14-debversion=1.1.1-5
-      - postgresql-plpython3-14=14.18-0ubuntu0.22.04.1
+      - postgresql-plpython3-14=14.19-0ubuntu0.22.04.1
       - postgresql-contrib=14+238
       - postgresql-plperl-14
       - postgresql-14-similarity


### PR DESCRIPTION
Issue:

The new PostgreSQL 14.19 has been released https://www.postgresql.org/docs/release/14.19/

Solution:

Bump charmed snap to the new minor version.