### PR TITLE
DPE-8470 Bump patroni from 3.2.2 to 3.3.8 (the latest Patroni 3.x)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,8 @@ plugs:
 
 package-repositories:
   - type: apt
+    ppa: data-platform/patroni
+  - type: apt
     ppa: data-platform/postgresql-16-timescaledb-tsl
   - type: apt
     ppa: data-platform/pgbackrest
@@ -220,7 +222,7 @@ parts:
       - prometheus-postgres-exporter=0.15.0-1
       - golang-github-prometheus-community-pgbouncer-exporter=0.7.0-1
       - python3-pysyncobj=0.3.12-1
-      - patroni=3.2.2-2
+      - patroni=3.3.8-0ubuntu0.24.04.1~ppa1
       - prometheus-pgbackrest-exporter=0.17.0+ds1-0ubuntu0.24.04.1~ppa1
       - python3-postgresql-ldap-sync=0.3.2-0ubuntu1
       - locales-all


### PR DESCRIPTION
There are fixes for sync replication and DCS timeouts (see DPE-8470).