### PR TITLE
DPE-8470 Bump patroni from 3.1.2 to 3.3.8 (the latest Patroni 3.x)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -246,7 +246,7 @@ parts:
       - prometheus-postgres-exporter=0.12.1-0ubuntu0.22.04.1~ppa1
       - golang-github-prometheus-community-pgbouncer-exporter=0.7.0-0ubuntu0.22.04.1~ppa1
       - python3-pysyncobj=0.3.12-0ubuntu0.22.04.1~ppa1
-      - patroni=3.1.2-0ubuntu0.22.04.1~ppa2
+      - patroni=3.3.8-0ubuntu0.22.04.1~ppa1
       - golang-github-woblerr-pgbackrest-exporter=0.16.2+ds1-0ubuntu0.22.04.1~ppa1
       - python3-postgresql-ldap-sync=0.3.2-0ubuntu1
       - locales-all


### PR DESCRIPTION
There are fixes for sync replication and DCS timeouts (see DPE-8470).