### PR TITLE
[DPE-5263] feat(psql): persist command history across sessions

### DIFF
--- a/snap/local/etc/postgresql-common/.psqlrc
+++ b/snap/local/etc/postgresql-common/.psqlrc
@@ -1,0 +1,1 @@
+\set HISTFILE ~/snap/charmed-postgresql/common/.psql_history

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -228,6 +228,8 @@ apps:
       - network-bind
   psql:
     command: usr/bin/psql
+    environment:
+      PSQLRC: $SNAP/etc/postgresql-common/.psqlrc
     plugs:
       - network
   syncobj-admin:


### PR DESCRIPTION
Add .psqlrc configuration to store psql history in persistent snap common directory and set PSQLRC environment variable for the psql app.

Related issue: https://github.com/canonical/postgresql-operator/issues/595