### PR TITLE
[DPE-9455] Bump PostgreSQL to 14.22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 # yamllint disable rule:line-length
 name: charmed-postgresql
 base: core22
-version: '14.20'
+version: '14.22'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management
@@ -255,7 +255,7 @@ parts:
       - libldap-common
       # Landscape deps
       - postgresql-14-debversion=1.1.1-5
-      - postgresql-plpython3-14=14.20-0ubuntu0.22.04.1
+      - postgresql-plpython3-14=14.22-0ubuntu0.22.04.1
       - postgresql-contrib=14+238
       - postgresql-plperl-14
       - postgresql-14-similarity


### PR DESCRIPTION
# Issue:

We ship outdated PostgreSQL 14.20.

# Solution:

Update PostgreSQL to 14.22.