### PR TITLE
[DPE-9492] Remove pins on deb packages (14/edge)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -241,22 +241,22 @@ parts:
   postgres-debs:
     plugin: nil
     stage-packages:
-      - postgresql=14+238
+      - postgresql
       - util-linux
-      - pgbouncer=1.21.0-0ubuntu0.22.04.1~ppa1
-      - pgbackrest=2.53-1ubuntu0.22.04.1~ppa1
-      - prometheus-postgres-exporter=0.12.1-0ubuntu0.22.04.1~ppa1
-      - golang-github-prometheus-community-pgbouncer-exporter=0.7.0-0ubuntu0.22.04.1~ppa1
-      - python3-pysyncobj=0.3.12-0ubuntu0.22.04.1~ppa1
-      - patroni=3.3.8-0ubuntu0.22.04.1~ppa1
-      - golang-github-woblerr-pgbackrest-exporter=0.16.2+ds1-0ubuntu0.22.04.1~ppa1
-      - python3-postgresql-ldap-sync=0.3.2-0ubuntu1
+      - pgbouncer
+      - pgbackrest
+      - prometheus-postgres-exporter
+      - golang-github-prometheus-community-pgbouncer-exporter
+      - python3-pysyncobj
+      - patroni
+      - golang-github-woblerr-pgbackrest-exporter
+      - python3-postgresql-ldap-sync
       - locales-all
       - libldap-common
       # Landscape deps
-      - postgresql-14-debversion=1.1.1-5
-      - postgresql-plpython3-14=14.22-0ubuntu0.22.04.1
-      - postgresql-contrib=14+238
+      - postgresql-14-debversion
+      - postgresql-plpython3-14
+      - postgresql-contrib
       - postgresql-plperl-14
       - postgresql-14-similarity
       - postgresql-14-orafce


### PR DESCRIPTION
Remove deb pins to allow package to update from proper repositories.