### PR TITLE
[DPE-9616] feat: add default config paths for PostgreSQL tools

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,7 +103,7 @@ environment:
   LDAPCONF: $SNAP_DATA/etc/ldap/ldap.conf
   # Default socket directory for libpq-based commands (psql, pg_dump, etc.).
   # /tmp is used because strict confinement disallows /var/run as a layout
-  # target (see unix_socket_directories in config/patroni.yaml).
+  # target (see unix_socket_directories in local/config/patroni.yaml).
   PGHOST: /tmp
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,7 +103,7 @@ environment:
   LDAPCONF: $SNAP_DATA/etc/ldap/ldap.conf
   # Default socket directory for libpq-based commands (psql, pg_dump, etc.).
   # /tmp is used because strict confinement disallows /var/run as a layout
-  # target, and patroni places the socket there (unix_socket_directories).
+  # target (see unix_socket_directories in config/patroni.yaml).
   PGHOST: /tmp
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -104,7 +104,10 @@ environment:
   # Set the default PostgreSQL socket directory so that all libpq-based
   # commands (psql, pg_dump, pg_dumpall, pg_restore, etc.) find the socket
   # without requiring the user to pass -h /tmp manually.
-  # The socket is placed in /tmp by patroni (unix_socket_directories: /tmp).
+  # /tmp is used because snap strict confinement does not allow writes to
+  # /var/run, and /run and /var/run cannot be used as layout targets.
+  # Patroni configures PostgreSQL to place the socket in /tmp
+  # (unix_socket_directories: /tmp in patroni.yaml).
   PGHOST: /tmp
 
 apps:
@@ -137,6 +140,7 @@ apps:
   patronictl:
     command: usr/bin/patronictl
     environment:
+      # Default config so patronictl works without -c/--config-file.
       PATRONICTL_CONFIG_FILE: $SNAP_DATA/etc/patroni/patroni.yaml
     plugs:
       - network
@@ -197,6 +201,7 @@ apps:
   pgbackrest:
     command: usr/bin/pgbackrest
     environment:
+      # Default config so pgbackrest works without --config.
       PGBACKREST_CONFIG: $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
     plugs:
       - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,6 +101,11 @@ environment:
   # The default /etc/ldap/ldap.conf file is not readable for the snap user.
   # (https://manpages.debian.org/jessie/libldap-2.4-2/ldap.conf.5.en.html)
   LDAPCONF: $SNAP_DATA/etc/ldap/ldap.conf
+  # Set the default PostgreSQL socket directory so that all libpq-based
+  # commands (psql, pg_dump, pg_dumpall, pg_restore, etc.) find the socket
+  # without requiring the user to pass -h /tmp manually.
+  # The socket is placed in /tmp by patroni (unix_socket_directories: /tmp).
+  PGHOST: /tmp
 
 apps:
   createdb:
@@ -131,6 +136,8 @@ apps:
     command: usr/bin/patroni_raft_controller
   patronictl:
     command: usr/bin/patronictl
+    environment:
+      PATRONICTL_CONFIG_FILE: $SNAP_DATA/etc/patroni/patroni.yaml
     plugs:
       - network
   patroni-aws:
@@ -189,6 +196,8 @@ apps:
     command: usr/sbin/pg_updatedicts
   pgbackrest:
     command: usr/bin/pgbackrest
+    environment:
+      PGBACKREST_CONFIG: $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
     plugs:
       - network
   pgbackrest-service:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,13 +101,9 @@ environment:
   # The default /etc/ldap/ldap.conf file is not readable for the snap user.
   # (https://manpages.debian.org/jessie/libldap-2.4-2/ldap.conf.5.en.html)
   LDAPCONF: $SNAP_DATA/etc/ldap/ldap.conf
-  # Set the default PostgreSQL socket directory so that all libpq-based
-  # commands (psql, pg_dump, pg_dumpall, pg_restore, etc.) find the socket
-  # without requiring the user to pass -h /tmp manually.
-  # /tmp is used because snap strict confinement does not allow writes to
-  # /var/run, and /run and /var/run cannot be used as layout targets.
-  # Patroni configures PostgreSQL to place the socket in /tmp
-  # (unix_socket_directories: /tmp in patroni.yaml).
+  # Default socket directory for libpq-based commands (psql, pg_dump, etc.).
+  # /tmp is used because strict confinement disallows /var/run as a layout
+  # target, and patroni places the socket there (unix_socket_directories).
   PGHOST: /tmp
 
 apps:


### PR DESCRIPTION
## Issue

PostgreSQL client commands in the snap (`pg-dumpall`, `psql`, `pg-dump`, etc.) default to looking for the Unix socket at `/var/run/postgresql/.s.PGSQL.5432`, but the snap places the socket at `/tmp/.s.PGSQL.5432` (configured via `unix_socket_directories: /tmp` in patroni.yaml). This forces users to pass `-h /tmp` on every invocation.

The reason for using `/tmp` is snap strict confinement: `/var/run` is not writable by strictly confined snaps, and both `/run` and `/var/run` are [explicitly disallowed as layout targets](https://documentation.ubuntu.com/snapcraft/stable/reference/layouts/). Meanwhile, `/tmp` is a [private per-snap directory](https://snapcraft.io/docs/explanation/security/security-policies/) set up via mount namespace isolation, making it one of the few viable locations for the PostgreSQL socket.

Similarly, `patronictl` and `pgbackrest` require users to manually specify their config file paths (`-c` / `--config`) because the snap-specific locations differ from system defaults.

## Solution

Set default environment variables in `snapcraft.yaml` so all snap commands find the socket and config files automatically:

- **`PGHOST: /tmp`** (global) — All libpq-based commands (`psql`, `pg_dump`, `pg_dumpall`, `pg_restore`, `pg_isready`, `createdb`, `createuser`, `pgbench`, `pg_basebackup`, etc.) now connect to the correct socket without `-h /tmp`. Users can still override this with `-h <host>` or by setting `PGHOST` in their shell.
- **`PATRONICTL_CONFIG_FILE`** (per-app on `patronictl`) — `patronictl` finds its config at `$SNAP_DATA/etc/patroni/patroni.yaml` without `-c`.
- **`PGBACKREST_CONFIG`** (per-app on `pgbackrest`) — `pgbackrest` finds its config at `$SNAP_DATA/etc/pgbackrest/pgbackrest.conf` without `--config`.

`PGHOST` is set globally rather than per-app because it is a libpq client-side variable that only affects commands which do not specify a host explicitly. All daemon services (patroni, prometheus-postgres-exporter, pgbackrest-service, pgbackrest-exporter, ldap-sync) manage their own connection parameters via config files or wrapper scripts, so `PGHOST` is inert for them — [libpq never consults environment variables when an explicit host is provided](https://www.postgresql.org/docs/current/libpq-envars.html).

Validated by deploying the `postgresql` charm from `14/stable`, refreshing the snap to the custom build, and confirming that `psql`, `pg_dump`, `pg_dumpall`, `pg_restore`, `createdb`, `createuser`, `pgbench`, `pg_isready`, `patronictl`, and `pgbackrest` all succeed without manual path arguments. Patroni remained healthy throughout.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Related issue: https://github.com/canonical/charmed-postgresql-snap/issues/238.