### PR TITLE
[MISC] Concurency conflict (16/edge)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,6 @@
 # See LICENSE file for licensing details.
 name: Release to Snap Store
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches:


### PR DESCRIPTION
Manual dispatch of the release flow fails with:
```
Release to Snap Store
Canceling since a deadlock was detected for concurrency group: 'Release to Snap Store-refs/heads/16/edge' between a top level workflow and 'Tests'

```
Removing concurrency group from release.