### PR TITLE
[MISC] Concurency conflict (14/edge)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,6 @@
 # See LICENSE file for licensing details.
 name: Release to Snap Store
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches:


### PR DESCRIPTION
Port of https://github.com/canonical/charmed-postgresql-snap/pull/240 for 14 edge.

Removing concurrency group from release.

