### PR TITLE
fix: add network plugs to patroni-raft-controller app

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -121,6 +121,9 @@ apps:
       - network-bind
   patroni-raft-controller:
     command: usr/bin/patroni_raft_controller
+    plugs:
+    - network
+    - network-bind
   patronictl:
     command: setpriv.sh $SNAP/usr/bin/patronictl
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,8 +122,8 @@ apps:
   patroni-raft-controller:
     command: usr/bin/patroni_raft_controller
     plugs:
-    - network
-    - network-bind
+      - network
+      - network-bind
   patronictl:
     command: setpriv.sh $SNAP/usr/bin/patronictl
     plugs:


### PR DESCRIPTION
Add network and network-bind plugs to patroni-raft-controller to allow network communication required for Raft consensus operations.