### PR TITLE
[DPE-9792] feat: add default config paths for PostgreSQL tools

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,10 @@ environment:
   # The default /etc/ldap/ldap.conf file is not readable for the snap user.
   # (https://manpages.debian.org/jessie/libldap-2.4-2/ldap.conf.5.en.html)
   LDAPCONF: $SNAP_DATA/etc/ldap/ldap.conf
+  # Default socket directory for libpq-based commands (psql, pg_dump, etc.).
+  # /tmp is used because strict confinement disallows /var/run as a layout
+  # target (see unix_socket_directories in local/config/patroni.yaml).
+  PGHOST: /tmp
 
 apps:
   createdb:
@@ -123,6 +127,9 @@ apps:
     command: usr/bin/patroni_raft_controller
   patronictl:
     command: setpriv.sh $SNAP/usr/bin/patronictl
+    environment:
+      # Default config so patronictl works without -c/--config-file.
+      PATRONICTL_CONFIG_FILE: $SNAP_DATA/etc/patroni/patroni.yaml
     plugs:
       - network
   patroni-aws:
@@ -165,6 +172,9 @@ apps:
     command: setpriv.sh $SNAP/usr/sbin/pg_updatedicts
   pgbackrest:
     command: setpriv.sh $SNAP/usr/bin/pgbackrest
+    environment:
+      # Default config so pgbackrest works without --config.
+      PGBACKREST_CONFIG: $SNAP_DATA/etc/pgbackrest/pgbackrest.conf
     plugs:
       - network
   pgbackrest-service:


### PR DESCRIPTION
## Issue

PostgreSQL client commands in the snap (`pg_dumpall`, `psql`, `pg_dump`, etc.) default to looking for the Unix socket at `/var/run/postgresql/.s.PGSQL.5432`, but the snap places the socket at `/tmp/.s.PGSQL.5432` (configured via `unix_socket_directories: /tmp` in patroni.yaml). This forces users to pass `-h /tmp` on every invocation.

The reason for using `/tmp` is snap strict confinement: `/var/run` is not writable by strictly confined snaps, and both `/run` and `/var/run` are [explicitly disallowed as layout targets](https://documentation.ubuntu.com/snapcraft/stable/reference/layouts/). Meanwhile, `/tmp` is a [private per-snap directory](https://snapcraft.io/docs/explanation/security/security-policies/) set up via mount namespace isolation, making it one of the few viable locations for the PostgreSQL socket.

Similarly, `patronictl` and `pgbackrest` require users to manually specify their config file paths (`-c` / `--config`) because the snap-specific locations differ from system defaults.

## Solution

Set default environment variables in `snapcraft.yaml` so all snap commands find the socket and config files automatically:

- **`PGHOST: /tmp`** (global) — All libpq-based commands (`psql`, `pg_dump`, `pg_dumpall`, `pg_restore`, `pg_isready`, `createdb`, `createuser`, `pgbench`, `pg_basebackup`, etc.) now connect to the correct socket without `-h /tmp`. Users can still override this with `-h` or by setting `PGHOST` in their shell.
- **`PATRONICTL_CONFIG_FILE`** (per-app on `patronictl`) — `patronictl` finds its config at `$SNAP_DATA/etc/patroni/patroni.yaml` without `-c`.
- **`PGBACKREST_CONFIG`** (per-app on `pgbackrest`) — `pgbackrest` finds its config at `$SNAP_DATA/etc/pgbackrest/pgbackrest.conf` without `--config`.

`PGHOST` is set globally rather than per-app because it is a libpq client-side variable that only affects commands which do not specify a host explicitly. All daemon services (patroni, prometheus-postgres-exporter, pgbackrest-service, pgbackrest-exporter, ldap-sync) manage their own connection parameters via config files or wrapper scripts, so `PGHOST` is inert for them — [libpq never consults environment variables when an explicit host is provided](https://www.postgresql.org/docs/current/libpq-envars.html).

This PR ports the same behavior already merged in `14/edge` to `16/edge`.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.

Related issue: https://github.com/canonical/charmed-postgresql-snap/issues/238

Port of https://github.com/canonical/charmed-postgresql-snap/pull/239