### PR TITLE
DPE-9977 Expose pg_waldump

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,6 +173,10 @@ apps:
     command: setpriv.sh $SNAP/usr/bin/pg_receivewal
   pg-updatedicts:
     command: setpriv.sh $SNAP/usr/sbin/pg_updatedicts
+  pg-waldump:
+    command: setpriv.sh $SNAP/usr/lib/postgresql/16/bin/pg_waldump
+    plugs:
+      - network
   pgbackrest:
     command: setpriv.sh $SNAP/usr/bin/pgbackrest
     environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -175,8 +175,6 @@ apps:
     command: setpriv.sh $SNAP/usr/sbin/pg_updatedicts
   pg-waldump:
     command: setpriv.sh $SNAP/usr/lib/postgresql/16/bin/pg_waldump
-    plugs:
-      - network
   pgbackrest:
     command: setpriv.sh $SNAP/usr/bin/pgbackrest
     environment:


### PR DESCRIPTION
# Issue 

pg_waldump is not exposed in snap making complex to troubleshoot the WALs content.

# Solution

Add pg_waldump to the snap apps, allowing WAL segment inspection via
charmed-postgresql.pg-waldump for debugging and diagnostics.

Fixes: https://github.com/canonical/charmed-postgresql-snap/issues/269