### PR TITLE
[DPE-9962] Rename default Patroni config to avoid missconfigurations

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -21,7 +21,6 @@ mkdir -p "${SNAP_COMMON}/var/log/pgbackrest"
 mkdir -p "${SNAP_COMMON}/var/log/pgbouncer"
 mkdir -p "${SNAP_COMMON}/var/log/postgresql"
 
-cp "${SNAP}/config/patroni.yaml" "${SNAP_DATA}/etc/patroni"
 cp "${SNAP}/etc/pgbackrest.conf" "${SNAP_DATA}/etc/pgbackrest"
 cp "${SNAP}/etc/ldap/ldap.conf" "${SNAP_DATA}/etc/ldap"
 


### PR DESCRIPTION
# Issue 

Sometimes, due to complex deployment instabilities, Charmed PostgreSQL snap can be installed already on machine by charm.py operator and launched by systemd/snapd on reboot, etc... effectively staring with wrong configs.

# Solution

Rename default config to avoid Patroni staring with wrong config paramts.
If config file is missing, Patroni failfast causing no damage/garbage in pgdata.

Could removed completely, but one day we hope to ship it usable without the charm.