### PR TITLE
DPE-8577 support non-snapped environments in start-pgbackrest-exporter

### DIFF
--- a/snap/local/start-pgbackrest-exporter.sh
+++ b/snap/local/start-pgbackrest-exporter.sh
@@ -9,7 +9,8 @@ else
     exec "${SNAP}/usr/bin/setpriv" \
         --clear-groups \
         --reuid _daemon_ \
-        --regid _daemon_ -- \
+        --regid _daemon_ \
+        -- \
         "${SNAP}/usr/bin/pgbackrest_exporter" \
         --backrest.config="/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf" "$@"
 fi

--- a/snap/local/start-pgbackrest-exporter.sh
+++ b/snap/local/start-pgbackrest-exporter.sh
@@ -6,6 +6,8 @@ if [ -z "${SNAP}" ]; then
     exec /usr/bin/pgbackrest_exporter \
         --backrest.config="/etc/pgbackrest.conf" "$@"
 else
+    # For security measures, daemons should not be run as sudo.
+    # Execute pgbackrest_exporter as the non-sudo user: _daemon_.
     exec "${SNAP}/usr/bin/setpriv" \
         --clear-groups \
         --reuid _daemon_ \

--- a/snap/local/start-pgbackrest-exporter.sh
+++ b/snap/local/start-pgbackrest-exporter.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-# For security measures, daemons should not be run as sudo. Execute pgbackrest_exporter as the non-sudo user: _daemon_.
-$SNAP/usr/bin/setpriv --clear-groups --reuid _daemon_ \
-  --regid _daemon_ -- $SNAP/usr/bin/pgbackrest_exporter --backrest.config="/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf" "$@"
+set -eo pipefail
+
+if [ -z "${SNAP}" ]; then
+    exec /usr/bin/pgbackrest_exporter \
+        --backrest.config="/etc/pgbackrest.conf" "$@"
+else
+    exec "${SNAP}/usr/bin/setpriv" \
+        --clear-groups \
+        --reuid _daemon_ \
+        --regid _daemon_ -- \
+        "${SNAP}/usr/bin/pgbackrest_exporter" \
+        --backrest.config="/var/snap/charmed-postgresql/current/etc/pgbackrest/pgbackrest.conf" "$@"
+fi
 


### PR DESCRIPTION
# Issue

It is hard to test pgbackrest-exporter on K8s

# Solution

Branch on $SNAP to handle both snap and non-snap (k8s) environments,
following the pattern from start-exporter.sh.
Non-snap mode runs the exporter directly with /etc/pgbackrest.conf;
snap mode keeps existing setpriv privilege-drop behavior.

Closes #169

Assisted-by: Claude:claude-4.6-opus