### PR TITLE
[DPE-9962] Stop installing default Patroni config to avoid missconfiguration

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -18,7 +18,6 @@ mkdir -p $SNAP_COMMON/var/log/pgbackrest
 mkdir -p $SNAP_COMMON/var/log/pgbouncer
 mkdir -p $SNAP_COMMON/var/log/postgresql
 
-cp $SNAP/config/patroni.yaml $SNAP_DATA/etc/patroni
 cp $SNAP/etc/pgbackrest.conf $SNAP_DATA/etc/pgbackrest
 cp $SNAP/etc/ldap/ldap.conf $SNAP_DATA/etc/ldap
 


### PR DESCRIPTION
Sometimes, due to complex deployment instabilities, Charmed PostgreSQL snap can be installed already on machine by charm.py operator and launched by systemd/snapd on reboot, etc... effectively staring with wrong configs.

The patroni.yaml file could be removed completely, but one day we hope to ship rock usable without the charm.

If config file is missing, Patroni failfast causing no damage/garbage in pgdata.

Backport form https://github.com/canonical/charmed-postgresql-snap/pull/271