### PR TITLE
[DPE-10366] Bump pySyncObj from 0.3.12 to 0.3.15 for PG16

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,8 @@ package-repositories:
   - type: apt
     ppa: data-platform/pgbackrest
   - type: apt
+    ppa: data-platform/python-pysyncobj
+  - type: apt
     ppa: data-platform/pgbackrest-exporter
   - type: apt
     ppa: data-platform/postgresql-ldap-sync


### PR DESCRIPTION
PG14 has already received the bump and more fixes planned for the lib, creating a PPA for PG16 as well.